### PR TITLE
Update scene.yaml

### DIFF
--- a/src/assets/scene.yaml
+++ b/src/assets/scene.yaml
@@ -1,4 +1,4 @@
-import: https://mapzen.com/carto/refill-style/4/refill-style.yaml
+import: https://mapzen.com/carto/refill-style/6/refill-style.yaml
 
 sources:
 


### PR DESCRIPTION
Per Mapzen's instructions:

Hi Gabriel,

Who can I contact at the Boston Globe about your old snow map? It needs a slight tweak to in how it references Mapzen API keys. 

https://apps.bostonglobe.com/metro/graphics/2016/12/snow-totals/[apps.bostonglobe.com]

While it doesn't matter so much for this old one, if your former colleagues are planning to re-use it for snow falls totals for this storm it'd be best to fix it.

Looks like it's setting the key in both the source url section, and a different one in the url_params section:

Now the map requests:

https://tile.mapzen.com/mapzen/vector/v1/all/7/43/47.topojson?api_key=mapzen-v3U3y5X&api_key=vector-tiles-W2tPU-Y[tile.mapzen.com]

But it should just request:

https://tile.mapzen.com/mapzen/vector/v1/all/7/43/47.topojson?api_key=mapzen-v3U3y5X[tile.mapzen.com]

(as mapzen-v3U3y5X is the key associated with your project)

The URL snafu is coming from using this older version of Refill in your scene file which didn’t :

https://apps.bostonglobe.com/metro/graphics/2016/12/snow-totals/assets/scene.yaml[apps.bostonglobe.com]

If you change this line:

import: https://mapzen.com/carto/refill-style/4/refill-style.yaml[mapzen.com]

to

import: https://mapzen.com/carto/refill-style/6/refill-style.yaml[mapzen.com]

It should “just work” as that newer one fixes the url_param bug.

Thanks,

_Nathaniel V. KELSO
  VP Data & Cartography
  Mapzen